### PR TITLE
Add meeting infos

### DIFF
--- a/_annual_meetings/annual_meeting_2026.md
+++ b/_annual_meetings/annual_meeting_2026.md
@@ -2,8 +2,6 @@
 title: "SwissBIAS Annual Meeting 2026"
 ---
 
-# SwissBIAS Annual Meeting 2026 — Schedule
-
 ## Morning Session
 
 | Starts at | Who | What |

--- a/_annual_meetings/annual_meeting_2026.md
+++ b/_annual_meetings/annual_meeting_2026.md
@@ -1,3 +1,7 @@
+---
+title: "SwissBIAS Annual Meeting 2026"
+---
+
 # SwissBIAS Annual Meeting 2026 — Schedule
 
 ## Morning Session

--- a/_annual_meetings/annual_meeting_2026.md
+++ b/_annual_meetings/annual_meeting_2026.md
@@ -1,0 +1,28 @@
+# SwissBIAS Annual Meeting 2026 — Schedule
+
+## Morning Session
+
+| Starts at | Who | What |
+|:---------:|-----|------|
+| 10:00 | SwissBIAS Board | Welcoming |
+| 10:15 | Nezar Bahou, University of Bern | Self-supervised learning and interactive latent space |
+| 10:35 | Lucien Hinderling, University of Bern | Smart Microscopes: From Automation to Autonomy |
+| 11:10 | *Discussion* | — |
+| 11:30 | *Break* | — |
+| 11:50 | Maciej Dobrzynski, University of Bern | Identification of emergent collective phenomena with ARCOS |
+| 12:10 | Nicole Repina, Friedrich Miescher Institute | Multiscale molecular to tissue-scale image quantification in 3D with Fractal and OME-Zarr |
+| 12:45 | *Discussion* | — |
+| 13:00 | *Lunch* | — |
+
+## Afternoon Session
+
+| Starts at | Who | What |
+|:---------:|-----|------|
+| 15:00 | Diego Morone, Università della Svizzera Italiana | Update your profile! |
+| 15:10 | Bastien Chesaux Dapia, EPFL | Expert-in-the-Loop |
+| 15:30 | Himanshu Bansal, Università della Svizzera Italiana | Generative AI |
+| 15:50 | Robert Haase, ScaDS AI, University of Dresden | How LLMs impact Bio Image Data Science |
+| 16:25 | *Discussion* | — |
+| 16:40 | Simon F. Nørrelykke, EPFL | BIAs communities |
+| 17:00 | *Break* | — |
+| 17:15 | *General Assembly* | — |

--- a/_config.yml
+++ b/_config.yml
@@ -305,5 +305,6 @@ collections:
     output: true
   annual_meetings:
     output: true
+    permalink: /:collection/:path/
     
 #    sort_by: last_name #doesn't seem to have any effect

--- a/_config.yml
+++ b/_config.yml
@@ -290,12 +290,20 @@ defaults:
       type: community
     values:
       layout: member
+  - scope:
+      path: ""
+      type: annual_meetings
+    values:
+      layout: single
+
       
 # collections: similar to posts, but content doesn't have to be grouped by date
 collections:
   members:
     output: true
   community:
+    output: true
+  annual_meetings:
     output: true
     
 #    sort_by: last_name #doesn't seem to have any effect

--- a/_pages/events.md
+++ b/_pages/events.md
@@ -19,7 +19,7 @@ Other global events can be found on [the image.sc forum](https://forum.image.sc/
 
 ### Past
 - [**SwissBIAS Annual Meeting
-  2026**](https://www.eventbrite.ch/e/swissbias-annual-meeting-2026-tickets-1984124721453?aff=oddtdtcreator),
+  2026**](https://swissbias.github.io/annual_meetings/annual_meeting_2026/),
   June 3rd 2026
 - Fabian Isensee presents [**nnInteractive**](https://swissbias.slack.com/files/U075S10EK8W/F0AKDMV1E2D/swissbias_seminar_march_2026.pdf), 19 March 10-11am
 - Roman Schwob presents [**convpaint**](https://drive.google.com/file/d/1smkpJRygnMU9h2FcrZVTHy5j8AhhXA6w/view?usp=sharing), 11 December 2025 10-11am

--- a/_pages/events.md
+++ b/_pages/events.md
@@ -18,9 +18,7 @@ Other global events can be found on [the image.sc forum](https://forum.image.sc/
 - Lorenzo Cerrone and Joel Lüthi present **ngio — Simple and Declarative OME-Zarr Processing in Python** on June 22nd, 10:30-12:30
 
 ### Past
-- [**SwissBIAS Annual Meeting
-  2026**](https://swissbias.github.io/annual_meetings/annual_meeting_2026/),
-  June 3rd 2026
+- [**SwissBIAS Annual Meeting 2026**]({% link _annual_meetings/annual_meeting_2026.md %}), June 3rd 2026
 - Fabian Isensee presents [**nnInteractive**](https://swissbias.slack.com/files/U075S10EK8W/F0AKDMV1E2D/swissbias_seminar_march_2026.pdf), 19 March 10-11am
 - Roman Schwob presents [**convpaint**](https://drive.google.com/file/d/1smkpJRygnMU9h2FcrZVTHy5j8AhhXA6w/view?usp=sharing), 11 December 2025 10-11am
 - Nicolas Chiarrutini presents [**QuPath Image Registration Workshop**](https://docs.google.com/forms/d/e/1FAIpQLSdEVfB_cPPIomMDFVJ2zj9CMMYITIqPvfjgMjvppCxGTzI5EQ/viewform), 26 November 2025 1-3pm


### PR DESCRIPTION
Hi everyone. Here's a PR that adds the information about the annual meetings. I created a separate folder for annual meetings where we can add individual markdown files for each meeting. Right now it's just a table with the program. We can then add links later for the presentation that people agree to share. Let me know if that looks ok to you. I'm not sure how to pre-visualize before merging. You can check out how it looks on my fork of the repo: https://guiwitz.github.io/SwissBIAS.github.io/annual_meetings/annual_meeting_2026/#morning-session